### PR TITLE
fix: Decode URL-encoded slashes for label

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -26,8 +26,9 @@ while IFS= read -r line; do
     owner=$(echo "$line" | cut -d'/' -f1)
     repo=$(echo "$line" | cut -d'/' -f2)
     image=$(echo "$line" | cut -d'/' -f3)
-    raw_pulls=$(curl -sSLN https://github.com/"$owner"/"$repo"/pkgs/container/"$image" | grep -Pzo '(?<=Total downloads</span>\n          <h3 title=")\d*')
-    pulls=$(curl -sSLN https://github.com/"$owner"/"$repo"/pkgs/container/"$image" | grep -Pzo "(?<=Total downloads</span>\n          <h3 title=\"$raw_pulls\">)[^<]*")
+    html=$(curl -sSLN "https://github.com/$owner/$repo/pkgs/container/$image")
+    raw_pulls=$(echo -e "$html" | grep -Pzo '(?<=Total downloads</span>\n          <h3 title=")\d*')
+    pulls=$(echo -e "$html" | grep -Pzo "(?<=Total downloads</span>\n          <h3 title=\"$raw_pulls\">)[^<]*")
     date=$(date -u +"%Y-%m-%d")
 
     if [ -n "$pulls" ]; then
@@ -63,13 +64,16 @@ for i in $(jq -r '.[] | @base64' index.json); do
     my $owner = $ENV{"owner"};
     my $repo = $ENV{"repo"};
     my $image = $ENV{"image"};
+    my $label = $ENV{"image"};
 
     # replace any "%" with "%25"
     $owner =~ s/%/%25/g;
     $repo =~ s/%/%25/g;
     $image =~ s/%/%25/g;
+    # decode URL-encoded slashes for label
+    $label =~ s/%2F/\//g;
 
-    s/\n\n(\[!\[.*)\n\n/\n\n$1 \[!\[$owner\/$repo\/$image\]\(https:\/\/img.shields.io\/badge\/dynamic\/json\?url=https%3A%2F%2Fraw.githubusercontent.com%2Fipitio%2Fghcr-pulls%2Fmaster%2Findex.json\&query=%24%5B%3F(%40.owner%3D%3D%22$owner%22%20%26%26%20%40.repo%3D%3D%22$repo%22%20%26%26%20%40.image%3D%3D%22$image%22)%5D.pulls\&label=$image\)\]\(https:\/\/github.com\/$owner\/$repo\/pkgs\/container\/$image\)\n\n/g;
+    s/\n\n(\[!\[.*)\n\n/\n\n$1 \[!\[$owner\/$repo\/$image\]\(https:\/\/img.shields.io\/badge\/dynamic\/json\?url=https%3A%2F%2Fraw.githubusercontent.com%2Fipitio%2Fghcr-pulls%2Fmaster%2Findex.json\&query=%24%5B%3F(%40.owner%3D%3D%22$owner%22%20%26%26%20%40.repo%3D%3D%22$repo%22%20%26%26%20%40.image%3D%3D%22$image%22)%5D.pulls\&label=$label\)\]\(https:\/\/github.com\/$owner\/$repo\/pkgs\/container\/$image\)\n\n/g;
 ' README.md > README.tmp && [ -f README.tmp ] && mv README.tmp README.md || :
 
     printf "%s (%s) pulls \t\t\t | %s/%s/%s\n" "$pulls" "$raw_pulls" "$owner" "$repo" "$image"


### PR DESCRIPTION
### Fixes
* Decode URL-encoded slashes for label: `argo-cd%2Fargocd` -> `argo-cd/argocd`

### Improvements
* Download website only 1 time per image